### PR TITLE
Compression is a WHATWG standard now

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,6 +2,7 @@
 Group: WHATWG
 H1: Compression
 Shortname: compression
+Text Macro: TWITTER compressionstandard
 Abstract: This document defines a set of JavaScript APIs to compress and decompress streams of binary data.
 Indent: 2
 Markup Shorthands: markdown yes

--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,6 @@ Text Macro: TWITTER compressionstandard
 Abstract: This document defines a set of JavaScript APIs to compress and decompress streams of binary data.
 Indent: 2
 Markup Shorthands: markdown yes
-Boilerplate: omit conformance
 </pre>
 <pre class="link-defaults">
 spec:streams; type:interface; text:ReadableStream

--- a/index.bs
+++ b/index.bs
@@ -1,16 +1,8 @@
 <pre class="metadata">
-Title: Compression Streams
+Group: WHATWG
+H1: Compression
 Shortname: compression
-Level: none
-Status: CG-DRAFT
-Group: wicg
-ED: https://wicg.github.io/compression/
-Editor: Canon Mukai, Google
-Editor: Adam Rice, Google
-Abstract:
-  This document defines a set of JavaScript APIs to compress and decompress
-  streams of binary data.
-Repository: wicg/compression
+Abstract: This document defines a set of JavaScript APIs to compress and decompress streams of binary data.
 Indent: 2
 Markup Shorthands: markdown yes
 Boilerplate: omit conformance
@@ -230,5 +222,9 @@ function decompressBlob(blob) {
 }
 </pre>
 
-# Acknowledgments #  {#acknowledgments}
-The editors wish to thank Domenic Denicola and Yutaka Hirano, for their support.
+<h2 class="no-num" id="acknowledgments">Acknowledgments</h2>
+Thanks to Canon Mukai, Domenic Denicola, and Yutaka Hirano, for their support.
+
+This standard is written by Adam Rice (<a href="https://google.com">Google</a>, <a href="mailto:ricea@chromium.org">ricea@chromium.org</a>).
+
+<p boilerplate=ipr>This Living Standard was originally developed in the W3C WICG, where it was available under the [W3C Software and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compression/60.html" title="Last updated on May 28, 2024, 2:42 PM UTC (9cef4c6)">Preview</a> | <a href="https://whatpr.org/compression/60/34d39f1...9cef4c6.html" title="Last updated on May 28, 2024, 2:42 PM UTC (9cef4c6)">Diff</a>